### PR TITLE
Fix for caching colortemp range

### DIFF
--- a/lights/color-temperature.js
+++ b/lights/color-temperature.js
@@ -51,8 +51,8 @@ module.exports = Thing.mixin(Parent => class extends Parent {
 		}
 
 		const range = { min, max };
-		if(! isDeepEqual(this[colorTemperatureRange], range)) {
-			this[colorTemperatureRange] = range;
+		if(! isDeepEqual(this.colorTemperatureRange, range)) {
+			this.colorTemperatureRange = range;
 			this.emitEvent('colorTemperatureRangeChanged', range);
 		}
 	}


### PR DESCRIPTION
See https://github.com/aholstenson/miio/issues/222

==add Bedside Lamp support==
miio/lib/models.js
//in module.exports add one line
'yeelink.light.bslamp1': YeelightColor,

==fix color temperature setting==
abstract-things/lights/color-temperature.js
//line 54~55
--	if(! isDeepEqual(this[colorTemperatureRange], range)) {
--	this[colorTemperatureRange] = range;
++	if(! isDeepEqual(this.colorTemperatureRange, range)) {
++	this.colorTemperatureRange = range;

Then your can use this code: light.color('5020K') without error